### PR TITLE
use venv's pip to upgrade pip

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,7 @@ if [ ! -d "venv" ]; then
 fi
 
 # Upgrade pip before `pip install`
-python -m pip install --upgrade pip
+./venv/bin/python -m pip install --upgrade pip
 
 # Install the custom diffusers version from GitHub
 ./venv/bin/pip install git+https://github.com/EtienneDosSantos/diffusers.git@wuerstchen-v3


### PR DESCRIPTION
The `install.sh` script makes an attempt to upgrade `pip` before installing the requirements however it's using the default `python` binary which is totally dependent on the environment/shell setup and is almost certainly not the virtual environment's `python` or `pip`. 

This PR makes sure that the `pip` that is upgraded is the one used to install stable cascade's requirements